### PR TITLE
Undo optimization that breaks compound BiStream operations

### DIFF
--- a/core/src/test/java/com/google/mu/util/stream/BiStreamCompoundTest.java
+++ b/core/src/test/java/com/google/mu/util/stream/BiStreamCompoundTest.java
@@ -1,0 +1,82 @@
+/*****************************************************************************
+ * ------------------------------------------------------------------------- *
+ * Licensed under the Apache License, Version 2.0 (the "License");           *
+ * you may not use this file except in compliance with the License.          *
+ * You may obtain a copy of the License at                                   *
+ *                                                                           *
+ * http://www.apache.org/licenses/LICENSE-2.0                                *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing, software       *
+ * distributed under the License is distributed on an "AS IS" BASIS,         *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+ * See the License for the specific language governing permissions and       *
+ * limitations under the License.                                            *
+ *****************************************************************************/
+package com.google.mu.util.stream;
+
+import static com.google.mu.util.stream.BiStreamTest.assertKeyValues;
+
+import com.google.common.collect.ImmutableMultimap;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BiStreamCompoundTest {
+
+  @Test public void testMappedValuesAndSortedByKeys() {
+    assertKeyValues(
+            BiStream.of("a", 1, "c", 2, "b", 3)
+                .mapValues(Function.identity())
+                .sortedByKeys(Comparator.naturalOrder()))
+        .containsExactlyEntriesIn(ImmutableMultimap.of("a", 1, "b", 3, "c", 2))
+        .inOrder();
+  }
+
+  @Test public void testMappedValuesAndSortedByValues() {
+    assertKeyValues(
+            BiStream.of("a", 3, "b", 1, "c", 2)
+                .mapValues(Function.identity())
+                .sortedByValues(Comparator.naturalOrder()))
+        .containsExactlyEntriesIn(ImmutableMultimap.of("b", 1, "c", 2, "a", 3))
+        .inOrder();
+  }
+
+  @Test public void testMappedValuesAndSorted() {
+    assertKeyValues(
+            BiStream.of("b", 10, "a", 11, "a", 22)
+                .mapValues(Function.identity())
+                .sorted(Comparator.naturalOrder(), Comparator.naturalOrder()))
+        .containsExactlyEntriesIn(ImmutableMultimap.of("a", 11, "a", 22, "b", 10))
+        .inOrder();
+  }
+
+  @Test public void testMappedKeysAndSortedByKeys() {
+    assertKeyValues(
+            BiStream.of("a", 1, "c", 2, "b", 3)
+                .mapKeys(Function.identity())
+                .sortedByKeys(Comparator.naturalOrder()))
+        .containsExactlyEntriesIn(ImmutableMultimap.of("a", 1, "b", 3, "c", 2))
+        .inOrder();
+  }
+
+  @Test public void testMappedKeysAndSortedByValues() {
+    assertKeyValues(
+            BiStream.of("a", 3, "b", 1, "c", 2)
+                .mapKeys(Function.identity())
+                .sortedByValues(Comparator.naturalOrder()))
+        .containsExactlyEntriesIn(ImmutableMultimap.of("b", 1, "c", 2, "a", 3))
+        .inOrder();
+  }
+
+  @Test public void testMappedKeysAndSorted() {
+    assertKeyValues(
+            BiStream.of("b", 10, "a", 11, "a", 22)
+                .mapKeys(Function.identity())
+                .sorted(Comparator.naturalOrder(), Comparator.naturalOrder()))
+        .containsExactlyEntriesIn(ImmutableMultimap.of("a", 11, "a", 22, "b", 10))
+        .inOrder();
+  }
+}

--- a/core/src/test/java/com/google/mu/util/stream/BiStreamTest.java
+++ b/core/src/test/java/com/google/mu/util/stream/BiStreamTest.java
@@ -545,7 +545,7 @@ public class BiStreamTest {
     tester.testAllPublicInstanceMethods(BiStream.empty());
   }
 
-  private static <K, V> MultimapSubject assertKeyValues(BiStream<K, V> stream) {
+  static <K, V> MultimapSubject assertKeyValues(BiStream<K, V> stream) {
     Multimap<K, V> multimap = stream.<Multimap<K, V>>collect(BiStreamTest::toLinkedListMultimap);
     return assertThat(multimap);
   }


### PR DESCRIPTION
Undoes the optimization in e5d4516 which broke compound map + sort operations on BiStreams (https://github.com/google/mug/issues/8).

Without f094b07 four tests fail:
```
Failed tests:   testMappedKeysAndSortedByValues(com.google.mu.util.stream.BiStreamCompoundTest): Not true that <{c=[2, 2, 2]}> contains exactly <{b=[1], c=[2], a=[3]}>. It is missing <{b=[1], a=[3]}> and has unexpected items <{c=[2 [2 copies]]}>
  testMappedKeysAndSortedByKeys(com.google.mu.util.stream.BiStreamCompoundTest): Not true that <{b=[3, 3, 3]}> contains exactly <{a=[1], b=[3], c=[2]}>. It is missing <{a=[1], c=[2]}> and has unexpected items <{b=[3 [2 copies]]}>
  testMappedValuesAndSortedByValues(com.google.mu.util.stream.BiStreamCompoundTest): Not true that <{c=[2, 2, 2]}> contains exactly <{b=[1], c=[2], a=[3]}>. It is missing <{b=[1], a=[3]}> and has unexpected items <{c=[2 [2 copies]]}>
  testMappedValuesAndSortedByKeys(com.google.mu.util.stream.BiStreamCompoundTest): Not true that <{b=[3, 3, 3]}> contains exactly <{a=[1], b=[3], c=[2]}>. It is missing <{a=[1], c=[2]}> and has unexpected items <{b=[3 [2 copies]]}>
```

Please let me know if this is not the direction you'd like to go or if there should be any changes. Thanks!