### PR TITLE
Fix Type Mismatch Error in Maybe Class

### DIFF
--- a/mug/src/main/java/com/google/mu/util/Maybe.java
+++ b/mug/src/main/java/com/google/mu/util/Maybe.java
@@ -197,7 +197,8 @@ public abstract class Maybe<T, E extends Throwable> {
    */
   public static <T, E extends Throwable> Stream<Maybe<T, E>> maybeStream(
       CheckedSupplier<? extends Stream<? extends T>, E> supplier) {
-    return maybe(supplier).map(s -> s.map(Maybe::<T, E>of)).orElse(e -> Stream.of(except(e)));
+      // assigning the correct value to the except by calling it using the static variable
+      return maybe(supplier).map(s -> s.map(Maybe::<T, E>of)).orElse(e -> Stream.of(Maybe.<T,E>except(e)));
   }
 
   /**

--- a/mug/src/main/java/com/google/mu/util/Maybe.java
+++ b/mug/src/main/java/com/google/mu/util/Maybe.java
@@ -151,7 +151,9 @@ public abstract class Maybe<T, E extends Throwable> {
     requireNonNull(handler);
     return map(Stream::of).orElse(e -> {
       handler.accept(e);
-      return Stream.empty();
+
+      // Setting the empty stream to return stream of type <T>
+        return Stream.<T>empty();
     });
   }
 

--- a/mug/src/main/java/com/google/mu/util/Maybe.java
+++ b/mug/src/main/java/com/google/mu/util/Maybe.java
@@ -481,7 +481,7 @@ public abstract class Maybe<T, E extends Throwable> {
   /** Adapts a {@code Maybe<Stream<T>, E>} to {@code Stream<Maybe<T, E>}. */
   private static <T, E extends Throwable> Stream<Maybe<T, E>> maybeStream(
       Maybe<? extends Stream<? extends T>, ? extends E> maybeStream) {
-    return maybeStream.map(s -> s.map(Maybe::<T, E>of)).orElse(e -> Stream.of(except(e)));
+    return maybeStream.map(s -> s.map(Maybe::<T, E>of)).orElse(e -> Stream.of(Maybe.<T,E>except(e)));
   }
 
   private static <E extends Throwable> E cleanupInterruption(E exception) {


### PR DESCRIPTION
This pull request addresses issue #36, which was reported as a type mismatch error in the Maybe.java class of the com.google.mu.util package. The issue resulted in red lines appearing in the IntelliJ IDEA editor and potentially caused runtime errors due to incorrect type annotations and declarations in certain methods.

Changes Made:

    Corrected the type annotations and declarations in the following methods:
        public final <X extends Throwable> Stream<T> catching(
        public static <T, E extends Throwable> Stream<Maybe<T, E>> maybeStream(

Expected Behavior:

With these corrections, the type mismatch error has been resolved, and the code in the Maybe.java class now conforms to expected type definitions. This change enhances code readability and eliminates the possibility of runtime errors.

Related Issue:

    Fixes #36: Type Mismatch Error in Maybe.java Class

Additional Notes:

Please review the changes and merge this pull request to maintain the code quality and reliability of the Maybe.java class. If you have any further feedback or questions, please feel free to discuss them in the comments.