### PR TITLE
BiStream.crossJoining() fails compiling in my local Eclipse. By addin…

### DIFF
--- a/mug/src/main/java/com/google/mu/util/stream/BiStream.java
+++ b/mug/src/main/java/com/google/mu/util/stream/BiStream.java
@@ -363,7 +363,7 @@ public abstract class BiStream<K, V> implements AutoCloseable {
     requireNonNull(right);
     return collectingAndThen(
         toList(),
-        left ->
+        (List<L> left) ->
             // If `right` is infinite, even limit(1) will result in infinite loop otherwise.
             left.isEmpty() ? empty() : concat(right.map(r -> from(left, identity(), l -> r))));
   }


### PR DESCRIPTION
…g a bit of extra type information (which looks reasonable to me), it fixes the Eclipse issue.

I guess this could just be the particular Eclipse version that I happen to use.

But seems nicer to make it compile for a popular IDE than not?