### PR TITLE
It seems we can use SOURCE retention for the @RequiresGuava annotations?

### DIFF
--- a/mug-bigquery/src/main/java/com/google/mu/annotations/RequiresBigQuery.java
+++ b/mug-bigquery/src/main/java/com/google/mu/annotations/RequiresBigQuery.java
@@ -2,6 +2,8 @@ package com.google.mu.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -10,5 +12,6 @@ import java.lang.annotation.Target;
  * @since 8.0
  */
 @Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
 @Documented
 public @interface RequiresBigQuery {}

--- a/mug-guava/src/main/java/com/google/mu/annotations/RequiresGuava.java
+++ b/mug-guava/src/main/java/com/google/mu/annotations/RequiresGuava.java
@@ -2,6 +2,8 @@ package com.google.mu.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -10,5 +12,6 @@ import java.lang.annotation.Target;
  * @since 8.0
  */
 @Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
 @Documented
 public @interface RequiresGuava {}

--- a/mug-protobuf/src/main/java/com/google/mu/annotations/RequiresProtobuf.java
+++ b/mug-protobuf/src/main/java/com/google/mu/annotations/RequiresProtobuf.java
@@ -2,6 +2,8 @@ package com.google.mu.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -10,5 +12,6 @@ import java.lang.annotation.Target;
  * @since 8.0
  */
 @Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
 @Documented
 public @interface RequiresProtobuf {}


### PR DESCRIPTION
They seem to be for documentation purposes?