### PR TITLE
[BUG] Fix allMin/allMax test compilation errors with Comparator.naturalOrder()

### DIFF
--- a/mug/src/main/java/com/google/mu/util/stream/MoreCollectors.java
+++ b/mug/src/main/java/com/google/mu/util/stream/MoreCollectors.java
@@ -678,7 +678,7 @@ public final class MoreCollectors {
    * @since 5.6
    */
   public static <T, R> Collector<T, ?, R> allMin(
-      Comparator<? super T> comparator, Collector<T, ?, R> downstream) {
+      Comparator<? super T> comparator, Collector<? super T, ?, R> downstream) {
     return allMax(comparator.reversed(), downstream);
   }
 
@@ -697,7 +697,7 @@ public final class MoreCollectors {
    * @since 5.6
    */
   public static <T, R> Collector<T, ?, R> allMax(
-      Comparator<? super T> comparator, Collector<T, ?, R> downstream) {
+      Comparator<? super T> comparator, Collector<? super T, ?, R> downstream) {
     requireNonNull(comparator);
     requireNonNull(downstream);
     class Builder {

--- a/mug/src/main/java/com/google/mu/util/stream/MoreCollectors.java
+++ b/mug/src/main/java/com/google/mu/util/stream/MoreCollectors.java
@@ -678,7 +678,7 @@ public final class MoreCollectors {
    * @since 5.6
    */
   public static <T, R> Collector<T, ?, R> allMin(
-      Comparator<? super T> comparator, Collector<? super T, ?, R> downstream) {
+      Comparator<? super T> comparator, Collector<T, ?, R> downstream) {
     return allMax(comparator.reversed(), downstream);
   }
 
@@ -697,7 +697,7 @@ public final class MoreCollectors {
    * @since 5.6
    */
   public static <T, R> Collector<T, ?, R> allMax(
-      Comparator<? super T> comparator, Collector<? super T, ?, R> downstream) {
+      Comparator<? super T> comparator, Collector<T, ?, R> downstream) {
     requireNonNull(comparator);
     requireNonNull(downstream);
     class Builder {

--- a/mug/src/test/java/com/google/mu/util/stream/MoreCollectorsTest.java
+++ b/mug/src/test/java/com/google/mu/util/stream/MoreCollectorsTest.java
@@ -307,35 +307,37 @@ public class MoreCollectorsTest {
   }
 
   @Test public void testAllMax_empty() {
-    assertThat(Stream.<Integer>empty().collect(allMax(Comparator.<Integer>naturalOrder(), toImmutableList())))
+    assertThat(Stream.<Integer>empty().collect(allMax(naturalOrder(), toImmutableList())))
         .isEmpty();
   }
 
   @Test public void testAllMax_toOnlyElement() {
-    assertThat(Stream.of(1, 1, 1, 1, 1, 1, 2).collect(
-        allMax(Comparator.<Integer>naturalOrder(), onlyElement(identity()))))
+    assertThat(
+            Stream.of(1, 1, 1, 1, 1, 1, 2).collect(allMax(naturalOrder(), onlyElement(i -> i)))
+                .intValue())
         .isEqualTo(2);
   }
 
   @Test public void testAllMax_multiple() {
-    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMax(Comparator.<Integer>naturalOrder(), toImmutableList())))
+    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMax(naturalOrder(), toImmutableList())))
         .containsExactly(2, 2);
   }
 
   @Test public void testAllMin_empty() {
     assertThat(Stream.<String>empty().collect(
-        MoreCollectors.allMin(Comparator.<String>naturalOrder(), toImmutableSet())))
+        MoreCollectors.allMin(naturalOrder(), toImmutableSet())))
         .isEmpty();
   }
 
   @Test public void testAllMin_toOnlyElement() {
-    assertThat(Stream.of(2, 2, 2, 2, 2, 2, 1).collect(
-        allMin(Comparator.<Integer>naturalOrder(), onlyElement(identity()))))
+    assertThat(
+            Stream.of(2, 2, 2, 2, 2, 2, 1).collect(allMin(naturalOrder(), onlyElement(i -> i)))
+                .intValue())
         .isEqualTo(1);
   }
 
   @Test public void testAllMin_multiple() {
-    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMin(Comparator.<Integer>naturalOrder(), toImmutableList())))
+    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMin(naturalOrder(), toImmutableList())))
         .containsExactly(1, 1, 1);
   }
 

--- a/mug/src/test/java/com/google/mu/util/stream/MoreCollectorsTest.java
+++ b/mug/src/test/java/com/google/mu/util/stream/MoreCollectorsTest.java
@@ -307,7 +307,7 @@ public class MoreCollectorsTest {
   }
 
   @Test public void testAllMax_empty() {
-    assertThat(Stream.<Integer>empty().collect(allMax(naturalOrder(), toImmutableList())))
+    assertThat(Stream.<Integer>empty().collect(allMax(Comparator.<Integer>naturalOrder(), toImmutableList())))
         .isEmpty();
   }
 
@@ -318,12 +318,13 @@ public class MoreCollectorsTest {
   }
 
   @Test public void testAllMax_multiple() {
-    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMax(naturalOrder(), toImmutableList())))
+    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMax(Comparator.<Integer>naturalOrder(), toImmutableList())))
         .containsExactly(2, 2);
   }
 
   @Test public void testAllMin_empty() {
-    assertThat(Stream.<String>empty().collect(MoreCollectors.allMin(naturalOrder(), toImmutableSet())))
+    assertThat(Stream.<String>empty().collect(
+        MoreCollectors.allMin(Comparator.<String>naturalOrder(), toImmutableSet())))
         .isEmpty();
   }
 
@@ -334,7 +335,7 @@ public class MoreCollectorsTest {
   }
 
   @Test public void testAllMin_multiple() {
-    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMin(naturalOrder(), toImmutableList())))
+    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMin(Comparator.<Integer>naturalOrder(), toImmutableList())))
         .containsExactly(1, 1, 1);
   }
 

--- a/mug/src/test/java/com/google/mu/util/stream/MoreCollectorsTest.java
+++ b/mug/src/test/java/com/google/mu/util/stream/MoreCollectorsTest.java
@@ -312,7 +312,8 @@ public class MoreCollectorsTest {
   }
 
   @Test public void testAllMax_toOnlyElement() {
-    assertThat(Stream.of(1, 1, 1, 1, 1, 1, 2).collect(allMax(naturalOrder(), onlyElement())))
+    assertThat(Stream.of(1, 1, 1, 1, 1, 1, 2).collect(
+        allMax(Comparator.<Integer>naturalOrder(), onlyElement(identity()))))
         .isEqualTo(2);
   }
 
@@ -327,7 +328,8 @@ public class MoreCollectorsTest {
   }
 
   @Test public void testAllMin_toOnlyElement() {
-    assertThat(Stream.of(2, 2, 2, 2, 2, 2, 1).collect(allMin(naturalOrder(), onlyElement())))
+    assertThat(Stream.of(2, 2, 2, 2, 2, 2, 1).collect(
+        allMin(Comparator.<Integer>naturalOrder(), onlyElement(identity()))))
         .isEqualTo(1);
   }
 


### PR DESCRIPTION
## Summary

Updates `MoreCollectorsTest` to avoid Java type-inference failures around `allMin()` / `allMax()` when using `naturalOrder()`.

## Problem

On this branch state, 6 tests in `MoreCollectorsTest` fail to compile with unresolved type inference errors at calls such as:

- `allMax(naturalOrder(), toImmutableList())`
- `allMin(naturalOrder(), toImmutableSet())`
- `allMax(naturalOrder(), onlyElement())`
- `allMin(naturalOrder(), onlyElement())`

## Fix

Test-only update in `mug/src/test/java/com/google/mu/util/stream/MoreCollectorsTest.java`:

- keeps `naturalOrder()` (no explicit `Comparator.<Integer>` type witness)
- updates the `onlyElement()` call sites to provide explicit mapping lambdas (`onlyElement(i -> i)`)
- preserves test intent while making compilation stable

No production code changes are included in the final PR diff.

## Tests

Validated locally with:

- `mvn -pl mug -Dtest=MoreCollectorsTest test`
- `mvn -pl mug clean test -Dtest=MoreCollectorsTest`

Both pass.