### PR TITLE
Fix type inference issue with naturalOrder() in allMax/allMin tests

### DIFF
--- a/mug/src/test/java/com/google/mu/util/stream/MoreCollectorsTest.java
+++ b/mug/src/test/java/com/google/mu/util/stream/MoreCollectorsTest.java
@@ -307,32 +307,32 @@ public class MoreCollectorsTest {
   }
 
   @Test public void testAllMax_empty() {
-    assertThat(Stream.<Integer>empty().collect(allMax(naturalOrder(), toImmutableList())))
+    assertThat(Stream.<Integer>empty().collect(allMax(Comparator.<Integer>naturalOrder(), toImmutableList())))
         .isEmpty();
   }
 
   @Test public void testAllMax_toOnlyElement() {
-    assertThat(Stream.of(1, 1, 1, 1, 1, 1, 2).collect(allMax(naturalOrder(), onlyElement())))
+    assertThat(Stream.of(1, 1, 1, 1, 1, 1, 2).collect(allMax(Comparator.<Integer>naturalOrder(), onlyElement())))
         .isEqualTo(2);
   }
 
   @Test public void testAllMax_multiple() {
-    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMax(naturalOrder(), toImmutableList())))
+    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMax(Comparator.<Integer>naturalOrder(), toImmutableList())))
         .containsExactly(2, 2);
   }
 
   @Test public void testAllMin_empty() {
-    assertThat(Stream.<String>empty().collect(MoreCollectors.allMin(naturalOrder(), toImmutableSet())))
+    assertThat(Stream.<String>empty().collect(MoreCollectors.allMin(Comparator.<String>naturalOrder(), toImmutableSet())))
         .isEmpty();
   }
 
   @Test public void testAllMin_toOnlyElement() {
-    assertThat(Stream.of(2, 2, 2, 2, 2, 2, 1).collect(allMin(naturalOrder(), onlyElement())))
+    assertThat(Stream.of(2, 2, 2, 2, 2, 2, 1).collect(allMin(Comparator.<Integer>naturalOrder(), onlyElement())))
         .isEqualTo(1);
   }
 
   @Test public void testAllMin_multiple() {
-    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMin(naturalOrder(), toImmutableList())))
+    assertThat(Stream.of(1, 1, 2, 1, 2).collect(allMin(Comparator.<Integer>naturalOrder(), toImmutableList())))
         .containsExactly(1, 1, 1);
   }
 


### PR DESCRIPTION
<img width="1811" height="70" alt="image" src="https://github.com/user-attachments/assets/196c0ce8-6508-4338-8263-b99ed910d828" />
<img width="1800" height="52" alt="image" src="https://github.com/user-attachments/assets/d70d7578-84a2-436f-9d20-de874dc76d3a" />


Fixes i made:
Added explicit type witness Comparator.<Integer/String>naturalOrder() in all allMax/allMin tests