### PR TITLE
Keep Java sources LF-normalized so the build works on Windows checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Java sources must keep LF in the working tree on every platform.
+#
+# ErrorProne's MisleadingEscapedSpace check reports an error when the `\s`
+# escape in a text block is not at the end of the line. On a CRLF checkout
+# every `\s` in the expected-error text blocks is followed by a CR, so the
+# build fails on Windows before any test runs.
+*.java text eol=lf


### PR DESCRIPTION
On Windows, a default clone (`core.autocrlf=true`) cannot build the project: `mvn test` fails during compilation, before running a single test.

```
[ERROR] dot-parse/src/test/java/com/google/common/labs/csv/CsvTest.java:[230,50]
        error: [MisleadingEscapedSpace] Using \s anywhere except at the end of a
        line in a text block is potentially misleading.
```

13 errors in total, across `CsvTest`, `OperatorTableTest`, `ParserTest` and `ParsersTest`.

**Cause:** the expected-error assertions use `\s` at the end of a text block line to pin the trailing space of `encountered: `. On a CRLF checkout that `\s` is followed by a CR, so ErrorProne's `MisleadingEscapedSpace` check no longer sees it at the end of the line and reports an error. On Linux CI the files are LF, so the check passes and the problem is invisible.

**Fix:** a `.gitattributes` forcing LF in the working tree for `*.java`. Nothing changes on Linux or macOS, and non-Java files are left alone.

**Verified** by cloning this branch with `core.autocrlf=true` and building with JDK 24:

- all `*.java` files check out with LF (`Parser.java`: 2657 LF, 0 CRLF), while non-Java files such as `README.md` keep the platform line endings
- `mvn test -pl dot-parse -am` → BUILD SUCCESS, whereas on `master` the same clone fails to compile

If you'd rather normalize the whole repository rather than just Java sources, `* text=auto` alongside (or instead of) the current rule works too — happy to change it.
