### PR TITLE
docs: fix two typos

### DIFF
--- a/mug-safesql/src/main/java/com/google/mu/safesql/README.md
+++ b/mug-safesql/src/main/java/com/google/mu/safesql/README.md
@@ -301,7 +301,7 @@ construction—areas where mistakes are easy to make and hard to find otherwise.
 
 ## Security Best Practices
 
-No additional best practices are needed: if your code compiles and the `SafeSql` object is succesfully constructed,
+No additional best practices are needed: if your code compiles and the `SafeSql` object is successfully constructed,
 your SQL is safe from injection.
 
 But just as a tip to avoid running into safety-related runtime errors during test: remember to identifier-quote

--- a/mug/src/main/java/com/google/mu/util/concurrent/README.md
+++ b/mug/src/main/java/com/google/mu/util/concurrent/README.md
@@ -6,7 +6,7 @@ Already, you can write intuitive code to call outgoing rpc, wait for the result,
 
 But sometimes when you serve a request, you need to invoke several outgoing rpcs, or read from db. Doing them sequentially results in longer request latency and you spend most of the time waiting.
 
-It makes sense to do these IO-bound operations concurrently. [JEP 453](https://openjdk.org/jeps/453) is still in preview. And the API as it is still feels a bit verbose. So we created a simpler API ([Fanout](https://google.github.io/mug/apidocs/com/google/mu/util/concurrent/Fanout.html)). It focuses on the most common fanout use case where the [ShutDownOnFailure](https://docs.oracle.com/en/java/javase/20/docs/api/jdk.incubator.concurrent/jdk/incubator/concurrent/StructuredTaskScope.ShutdownOnFailure.html) stragegy is sufficient.
+It makes sense to do these IO-bound operations concurrently. [JEP 453](https://openjdk.org/jeps/453) is still in preview. And the API as it is still feels a bit verbose. So we created a simpler API ([Fanout](https://google.github.io/mug/apidocs/com/google/mu/util/concurrent/Fanout.html)). It focuses on the most common fanout use case where the [ShutDownOnFailure](https://docs.oracle.com/en/java/javase/20/docs/api/jdk.incubator.concurrent/jdk/incubator/concurrent/StructuredTaskScope.ShutdownOnFailure.html) strategy is sufficient.
 
 For example if you need to concurrently read from db, and invoke a rpc to fetch some data:
 


### PR DESCRIPTION
Two typo fixes:

- `mug/src/main/java/com/google/mu/util/concurrent/README.md:9` — `stragegy` -> `strategy`
- `mug-safesql/src/main/java/com/google/mu/safesql/README.md:304` — `succesfully` -> `successfully`

Docs only.
