### PR TITLE
fix: close the input stream in consume

### DIFF
--- a/mug/src/main/java/com/google/mu/util/stream/MoreStreams.java
+++ b/mug/src/main/java/com/google/mu/util/stream/MoreStreams.java
@@ -523,6 +523,7 @@ public final class MoreStreams {
    *
    * <p>Upon return, to-be-consumed (up to {@code n}) elements have been consumed.
    * The {@code stream} reference should no longer be used.
+   * Closing the returned stream will close {@code stream}.
    *
    * @throws IllegalArgumentException if {@code n} is negative;
    * @since 9.9.5
@@ -534,7 +535,7 @@ public final class MoreStreams {
     Spliterator<T> spliterator = stream.spliterator();
     requireNonNull(consumer);
     for (int i = 0; i < n && spliterator.tryAdvance(consumer); i++) {}
-    return StreamSupport.stream(spliterator, /* parallel= */ false);
+    return StreamSupport.stream(spliterator, /* parallel= */ false).onClose(stream::close);
   }
 
   /**

--- a/mug/src/test/java/com/google/mu/util/stream/MoreStreamsTest.java
+++ b/mug/src/test/java/com/google/mu/util/stream/MoreStreamsTest.java
@@ -368,6 +368,25 @@ public class MoreStreamsTest {
         .inOrder();
   }
 
+  @Test public void consume_closeWithoutConsumingRemainder() {
+    List<String> closed = new ArrayList<>();
+    Stream<Integer> input = Stream.of(1, 2, 3).onClose(() -> closed.add("input"));
+    try (Stream<Integer> remaining = MoreStreams.consume(input, 1, x -> {})) {
+      assertThat(closed).isEmpty();
+    }
+    assertThat(closed).containsExactly("input");
+  }
+
+  @Test public void consume_closeAfterConsumingAllElements() {
+    List<String> closed = new ArrayList<>();
+    Stream<Integer> input = Stream.of(1, 2, 3).onClose(() -> closed.add("input"));
+    try (Stream<Integer> remaining = MoreStreams.consume(input, 3, x -> {})) {
+      assertThat(remaining).isEmpty();
+      assertThat(closed).isEmpty();
+    }
+    assertThat(closed).containsExactly("input");
+  }
+
   @Test public void consume_streamReferenceNoLongerUsable() {
     Stream<Integer> stream = Stream.of(1, 2, 3);
     Stream<Integer> remaining =


### PR DESCRIPTION
`consume()` has the same close-handler gap that #133 fixed in `withSideEffect()`: it returns a new stream without forwarding the input's close handler. Wrapping `Files.lines(...)` this way leaves the file open even when the returned stream is used in try-with-resources.

This adds `.onClose(stream::close)`, following `dice()` and `withSideEffect()`, and documents the close behavior. Consumption and traversal are unchanged.

Added two tests next to the existing `consume_` cases: closing without reading the remainder, and closing after `consume()` has exhausted the input. Both fail on the current master because the close handler never runs.

Checked with `mvn -B -ntp -pl mug test` on Temurin 24.0.2: 46,464 tests, zero failures/errors, 648 skipped. A separate before/after harness also checks consuming zero, some, all, or more than the available elements. The full multi-module build hasn't been run locally.

AI-assisted: Codex investigated the bug, wrote the fix and tests, and ran these checks.
