### PR TITLE
fix: let distinct() deduplicate consecutive groups

### DIFF
--- a/mug/src/main/java/com/google/mu/util/stream/BiStream.java
+++ b/mug/src/main/java/com/google/mu/util/stream/BiStream.java
@@ -1998,7 +1998,7 @@ public abstract class BiStream<K, V> implements AutoCloseable {
     requireNonNull(newRun);
     requireNonNull(groupAccumulator);
     requireNonNull(groupFinisher);
-    final int characteristics = Spliterator.ORDERED | Spliterator.DISTINCT;
+    final int characteristics = Spliterator.ORDERED;
 
     class Runner extends AbstractSpliterator<R> implements BiConsumer<K, V> {
       private final BiIterator<K, V> iterator = iterator();

--- a/mug/src/test/java/com/google/mu/util/stream/BiStreamTest.java
+++ b/mug/src/test/java/com/google/mu/util/stream/BiStreamTest.java
@@ -263,6 +263,21 @@ public class BiStreamTest {
         .inOrder();
   }
 
+  @Test public void testGroupConsecutiveIf_distinctWithCollector() {
+    assertThat(biStream(Stream.of("a", "b", "a"))
+        .groupConsecutiveIf(String::equals, toList())
+        .distinct())
+        .containsExactly(asList("a"), asList("b"))
+        .inOrder();
+  }
+
+  @Test public void testGroupConsecutiveIf_distinctWithReducer() {
+    assertThat(BiStream.of(1, 10, 2, 10)
+        .groupConsecutiveIf(Integer::equals, Integer::sum)
+        .distinct())
+        .containsExactly(10);
+  }
+
   /** Groups not by equal key, but by proximity. */
   @Test public void testGroupConsecutive_proximityGrouping_withReducer() {
     // Make sure nulls are grouped properly


### PR DESCRIPTION
Consecutive groups aren't necessarily distinct. For example:

```java
biStream(Stream.of("a", "b", "a"))
    .groupConsecutiveIf(String::equals, toList())
    .distinct()
```

This currently returns `[[a], [b], [a]]`, not `[[a], [b]]`. The grouping spliterator reports `DISTINCT`, so Java skips deduplication. Different groups can also reduce to the same value.

This removes the incorrect flag and keeps `ORDERED`. No changes to the grouping algorithm or public API. Added collector and reducer regression tests beside the existing grouping tests; both fail on the current master with the extra duplicate.

Checked with `mvn -B -ntp -pl mug test` on Temurin 24.0.2: 46,464 tests, zero failures/errors, 648 skipped. A separate before/after harness confirms the fix for sequential and parallel streams. The full multi-module build hasn't been run locally.

AI-assisted: Codex investigated the bug, wrote the fix and tests, and ran these checks.
