### PR TITLE
fix: preserve whitespace delimiters around quoted CSV fields

### DIFF
--- a/dot-parse/src/main/java/com/google/common/labs/csv/Csv.java
+++ b/dot-parse/src/main/java/com/google/common/labs/csv/Csv.java
@@ -66,7 +66,8 @@ import java.util.stream.Stream;
  * List<Map<String, String>> rows = CSV.parseToMaps(input).toList();
  * }</pre>
  *
- * <p>Starting from v9.5, spaces and tabs around double quoted fields are leniently ignored.
+ * <p>Starting from v9.5, spaces and tabs around double quoted fields are leniently ignored,
+ * unless the whitespace character is the configured delimiter.
  *
  * <p>Also starting from v9.5, to write to CSV format, use the {@link #join(Collection)} method to
  * join to CSV format:
@@ -106,15 +107,12 @@ import java.util.stream.Stream;
 @Immutable
 public final class Csv {
   private static final CharPredicate UNRESERVED_CHAR = noneOf("\"\r\n");
-  private static final Parser<?>.OrEmpty IGNORED_WHITESPACES = zeroOrMore("[ \t]");
   private static final Parser<?> NEW_LINE = anyOf("\n", "\r\n", "\r");
   private static final Parser<?> COMMENT = one('#').followedBy(zeroOrMore("[^\n]"));
   private static final Parser<String> QUOTED =
       anyOf(consecutive(isNot('"'), "quoted"), string("\"\"").thenReturn("\""))
           .zeroOrMore(Collectors.joining())
-          .between("\"", "\"")
-          // RFC doesn't allow spaces around quotes, but no ambiguity, no harm, why not?
-          .between(IGNORED_WHITESPACES, IGNORED_WHITESPACES);
+          .between("\"", "\"");
 
   /** Default CSV parser. Configurable using {@link #withComments} and {@link #withDelimiter}. */
   public static final Csv CSV = new Csv(',', /* allowsComments= */ false);
@@ -132,9 +130,11 @@ public final class Csv {
     this.delim = delim;
     this.allowsComments = allowsComments;
     this.regularChar = UNRESERVED_CHAR.and(isNot(delim)).precomputeForAscii();
+    Parser<?>.OrEmpty padding =
+        zeroOrMore(CharPredicate.anyOf(" \t").and(isNot(delim)), "whitespace");
     this.line = anyOf(
         NEW_LINE.thenReturn(List.of()), // empty line => [], not [""]
-        QUOTED.or(consecutive(regularChar, "unquoted field"))
+        QUOTED.between(padding, padding).or(consecutive(regularChar, "unquoted field"))
             .orElse("")
             .delimitedBy(String.valueOf(delim))
             .notEmpty()

--- a/dot-parse/src/test/java/com/google/common/labs/csv/CsvTest.java
+++ b/dot-parse/src/test/java/com/google/common/labs/csv/CsvTest.java
@@ -569,6 +569,35 @@ public final class CsvTest {
         .containsExactly(ImmutableList.of("a|b", "c\"d", "e\nf", "g h"));
   }
 
+  @Test public void join_withWhitespaceDelimiter_roundTrips() {
+    for (char delimiter : new char[] {'\t', ' '}) {
+      Csv csv = CSV.withDelimiter(delimiter);
+      for (List<String> fields : List.of(
+          List.of("a\"b", "second"),
+          List.of("a\"b", "c\"d"),
+          List.of("a\"b", "", ""),
+          List.of("", "", "a\"b"),
+          List.of("a\"b", "", "c\"d"))) {
+        String encoded = csv.join(fields);
+        assertThat(csv.parseToLists(encoded)).containsExactly(fields);
+        assertThat(csv.parseToLists(new StringReader(encoded))).containsExactly(fields);
+      }
+    }
+  }
+
+  @Test public void whitespaceDelimiter_preservesOtherPadding() {
+    Csv tabs = CSV.withDelimiter('\t');
+    String tabSeparated = " \"a\" \t \"b\" ";
+    assertThat(tabs.parseToLists(tabSeparated)).containsExactly(List.of("a", "b"));
+    assertThat(tabs.parseToLists(new StringReader(tabSeparated)))
+        .containsExactly(List.of("a", "b"));
+    Csv spaces = CSV.withDelimiter(' ');
+    String spaceSeparated = "\t\"a\"\t \t\"b\"\t";
+    assertThat(spaces.parseToLists(spaceSeparated)).containsExactly(List.of("a", "b"));
+    assertThat(spaces.parseToLists(new StringReader(spaceSeparated)))
+        .containsExactly(List.of("a", "b"));
+  }
+
   @Test public void usedAsCollector() {
     assertThat(Stream.of(1, "two,3", 4).collect(CSV.joining())).isEqualTo("1,\"two,3\",4");
   }


### PR DESCRIPTION
Quoted fields currently skip spaces and tabs on either side, even when that character is the configured delimiter. This breaks round trips with `CSV.withDelimiter('\t')` or `CSV.withDelimiter(' ')`:

```java
Csv csv = CSV.withDelimiter('\t');
String encoded = csv.join("a\"b", "", "");
csv.parseToLists(encoded).toList(); // currently [[a"b]], losing two empty columns
```

A nonempty field after the quoted field throws instead.

Move padding outside the shared quoted-field parser and exclude the configured delimiter from it. Other space/tab padding remains supported, including the existing default comma-delimited behavior.

Tests cover tab and space delimiters, leading/interior/trailing empty fields, adjacent quoted fields, and String/Reader input. Both new tests fail against the original implementation.

Validation: `mvn -B -ntp test` passed across the full reactor on JDK 24.0.2, including all 85 CSV tests. The original three-field example now round-trips without losing columns.

AI-assisted implementation and local verification with Codex.
